### PR TITLE
Fix off-by-one error with movement wrapping

### DIFF
--- a/game.rb
+++ b/game.rb
@@ -44,7 +44,7 @@ class Game
     if move == :left
       @player.x = @player.x > 0 ? @player.x-1 : @map_size-1;
     elsif move == :right
-      @player.x = @player.x < @map_size ? @player.x+1 : 0;
+      @player.x = @player.x < @map_size-1 ? @player.x+1 : 0;
     end
 
     if @player.x == @cheese_x


### PR DESCRIPTION
Wrapping now behaves symmetrically, although, of course, the cave&pit
need to be hidden/disabled to demonstrate!